### PR TITLE
Add config version & last_run time to puppet status.

### DIFF
--- a/examples/puppet_status.yml
+++ b/examples/puppet_status.yml
@@ -17,3 +17,11 @@ items:
     - failure:
         type:  'integer'
         regex: 'events:.*?failure:\s*(\d+)'
+
+    - version_config:
+        type:  'integer'
+        regex: 'version:.*?config:\s*(\d+)'
+
+    - last_run:
+        type:  'integer'
+        regex: 'time:.*?last_run:\s*(\d+)'


### PR DESCRIPTION
`version_config` is the timestamp of when the catalog was compiled.
`last_run` is the timestamp of when the puppet run completed.