### PR TITLE
Collect cache_catalog_status from puppet's last_run_report, modify syslog logging, and Continue updating item beyond first failure

### DIFF
--- a/examples/puppet_report.yml
+++ b/examples/puppet_report.yml
@@ -13,3 +13,7 @@ items:
     - system_state:
         type:  'string'
         regex: '^(?:  )?status:\s*(\S+)'
+
+    - cached_catalog_status:
+        type:  'string'
+        regex: '^(?:  )?cached_catalog_status:\s*(\S+)'

--- a/lib/snmpy/server.py
+++ b/lib/snmpy/server.py
@@ -62,7 +62,10 @@ class SnmpyAgent(object):
     def commit_data(self, mod):
         if isinstance(mod, snmpy.module.ValueModule):
             for item in mod:
-                self.snmp.replace_value(mod[item].oidstr, mod[item].value)
+                if mod[item].value is None:
+                    LOG.warn("'%s' doesn't have a value, ignoring", item)
+                else:
+                    self.snmp.replace_value(mod[item].oidstr, mod[item].value)
         elif isinstance(mod, snmpy.module.TableModule):
             try:
                 self.lock.acquire()

--- a/snmpy
+++ b/snmpy
@@ -79,7 +79,7 @@ def create_log(logger=None):
         if url.scheme in ('file', '') and url.path:
             log = logging.handlers.WatchedFileHandler(url.path)
         elif url.scheme.startswith('syslog'):
-            fmt = '%(module)s:%(lineno)d - %(threadName)s - %(message)s'
+            fmt = 'snmpy[%(process)d]: %(module)s:%(lineno)d - %(threadName)s - %(message)s'
             if url.scheme == 'syslog+tcp':
                 log = logging.handlers.SysLogHandler(address=(url.hostname or 'localhost', url.port or logging.handlers.SYSLOG_TCP_PORT), facility=arg.get('facility', ['user'])[0].lower(), socktype=socket.SOCK_STREAM)
             elif url.scheme == 'syslog+udp':


### PR DESCRIPTION
Collecting cache_catalog_status seems obvious from the title. :)

-----

For "Add program / pid to logging fmt for syslog logging", from the commit msg:

Without this, it is hard to find snmpy logging.  Logged lines look like:

>  May 15 13:41:33 ps0123 __init__:27 - Thread-2 - starting background task: start_fetch
>  May 15 13:41:33 ps0123 server:34 - MainThread - starting http server

Python's logging module '%(processName)s' didn't work, reporting "MainProcess" or "Process-#", such that similar log lines looked like:

>  May 16 11:16:41 ps0123 MainProcess[49672]: __init__:27 - Thread-2 - starting background task: start_fetch
>  May 16 11:16:41 ps0123 Process-1[49673]: server:34 - MainThread - starting http server

So fixed format to 'snmpy', so the same log lines will look like:

>   May 16 11:21:00 ps0123 snmpy[49866]: __init__:27 - Thread-2 - starting background task: start_fetch
>   May 16 11:21:00 ps0123 snmpy[49867]: server:34 - MainThread - starting http server

----

For "continue updating item beyond first failure", from the commit msg:

When updating snmp with items collected from a module, if there is a failure with a particular item, further updates for item collected successfully are not attempted.

Logs for that look like:

>  __init__:39 - Thread-14 - string expected instead of NoneType instance
>  __init__:42 - Thread-14 -   Traceback (most recent call last):
>  __init__:42 - Thread-14 -     File "/usr/lib/python2.7/dist-packages/snmpy/server.py", line 50, in start_fetch
>  __init__:42 - Thread-14 -       self.commit_data(mod)
>  __init__:42 - Thread-14 -     File "/usr/lib/python2.7/dist-packages/snmpy/server.py", line 65, in commit_data
>  __init__:42 - Thread-14 -       self.snmp.replace_value(mod[item].oidstr, mod[item].value)
>  __init__:42 - Thread-14 -     File "/usr/lib/python2.7/dist-packages/snmpy/agentx.py", line 522, in replace_value
>  __init__:42 - Thread-14 -       self.data[oid].set_value(val)
>  __init__:42 - Thread-14 -     File "/usr/lib/python2.7/dist-packages/snmpy/agentx.py", line 367, in set_value
>  __init__:42 - Thread-14 -       self._data.value = data
> __init__:42 - Thread-14 -   TypeError: string expected instead of NoneType instance

Change to code here tests if value is NoneType, and if so, logs a warning message like:

> server:66 - Thread-14 - item 'cached_catalog_status' doesn't have a value, ignoring

and continues updating the rest of the items.

