### PR TITLE
Issue #96: Continue updating item beyond first failure

### DIFF
--- a/lib/snmpy/server.py
+++ b/lib/snmpy/server.py
@@ -62,7 +62,10 @@ class SnmpyAgent(object):
     def commit_data(self, mod):
         if isinstance(mod, snmpy.module.ValueModule):
             for item in mod:
-                self.snmp.replace_value(mod[item].oidstr, mod[item].value)
+                if mod[item].value is None:
+                    LOG.warn("'%s' doesn't have a value, ignoring", item)
+                else:
+                    self.snmp.replace_value(mod[item].oidstr, mod[item].value)
         elif isinstance(mod, snmpy.module.TableModule):
             try:
                 self.lock.acquire()


### PR DESCRIPTION
When updating snmp with items collected from a module, if there is a failure with a particular item, further updates for item collected successfully are not attempted.

Logs for that look like:

> init:39 - Thread-14 - string expected instead of NoneType instance
> init:42 - Thread-14 - Traceback (most recent call last):
> init:42 - Thread-14 - File "/usr/lib/python2.7/dist-packages/snmpy/server.py", line 50, in start_fetch
> init:42 - Thread-14 - self.commit_data(mod)
> init:42 - Thread-14 - File "/usr/lib/python2.7/dist-packages/snmpy/server.py", line 65, in commit_data
> init:42 - Thread-14 - self.snmp.replace_value(mod[item].oidstr, mod[item].value)
> init:42 - Thread-14 - File "/usr/lib/python2.7/dist-packages/snmpy/agentx.py", line 522, in replace_value
> init:42 - Thread-14 - self.data[oid].set_value(val)
> init:42 - Thread-14 - File "/usr/lib/python2.7/dist-packages/snmpy/agentx.py", line 367, in set_value
> init:42 - Thread-14 - self._data.value = data
> init:42 - Thread-14 - TypeError: string expected instead of NoneType instance

Change to code here tests if value is NoneType, and if so, logs a warning message like:

> server:66 - Thread-14 - item 'cached_catalog_status' doesn't have a value, ignoring

and continues updating the rest of the items.

This commit closes #96