### PR TITLE
Issue #95: Add program / pid to logging fmt for syslog logging

### DIFF
--- a/snmpy
+++ b/snmpy
@@ -79,7 +79,7 @@ def create_log(logger=None):
         if url.scheme in ('file', '') and url.path:
             log = logging.handlers.WatchedFileHandler(url.path)
         elif url.scheme.startswith('syslog'):
-            fmt = '%(module)s:%(lineno)d - %(threadName)s - %(message)s'
+            fmt = 'snmpy[%(process)d]: %(module)s:%(lineno)d - %(threadName)s - %(message)s'
             if url.scheme == 'syslog+tcp':
                 log = logging.handlers.SysLogHandler(address=(url.hostname or 'localhost', url.port or logging.handlers.SYSLOG_TCP_PORT), facility=arg.get('facility', ['user'])[0].lower(), socktype=socket.SOCK_STREAM)
             elif url.scheme == 'syslog+udp':


### PR DESCRIPTION
Without this, it is hard to find snmpy logging. Logged lines look like:

May 15 13:41:33 ps0123 init:27 - Thread-2 - starting background task: start_fetch
May 15 13:41:33 ps0123 server:34 - MainThread - starting http server

Python's logging module '%(processName)s' didn't work, reporting "MainProcess" or "Process-#", such that similar log lines looked like:

May 16 11:16:41 ps0123 MainProcess[49672]: init:27 - Thread-2 - starting background task: start_fetch
May 16 11:16:41 ps0123 Process-1[49673]: server:34 - MainThread - starting http server

So fixed format to 'snmpy', so the same log lines will look like:

May 16 11:21:00 ps0123 snmpy[49866]: init:27 - Thread-2 - starting background task: start_fetch
May 16 11:21:00 ps0123 snmpy[49867]: server:34 - MainThread - starting http server

This commit closes #95