### PR TITLE
Conversion from python2->3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: snmpy
 Section: net
 Priority: extra
 Maintainer: Max Kalika <max.kalika+projects@gmail.com>
-Build-Depends: debhelper (>= 7), python (>= 2.7), python-setuptools,  dh-python, help2man
+Build-Depends: debhelper (>= 9), python3 (>= 3.6), python3-setuptools,  dh-python, help2man
 Standards-Version: 3.9.5
-XS-Python-Version: 2.7
+XS-Python-Version: 3.6
 
 Package: snmpy
 Architecture: any
-Depends: ${misc:Depends}, python (>= 2.7), python-yaml, libsnmp15 | libsnmp30, snmp-mibs-downloader
+Depends: ${misc:Depends}, python3 (>= 3.6), python3-yaml, libsnmp15 | libsnmp30 | libsnmp35, snmp-mibs-downloader
 Description: Modular system for extending net-snmp through its agentx mechanism.
  Allows creating python modules for extending net-snmp. Ships with
  several generic modules that can satisfy a number of use-cases by

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@
 export DH_VERBOSE=1
 
 %:
-	dh $@ --with python2
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_clean:
 	dh_clean

--- a/lib/snmpy/agentx.py
+++ b/lib/snmpy/agentx.py
@@ -449,7 +449,7 @@ class Table(object):
 
         row_iter = self.table.contents.table.contents.first_row
         while bool(row_iter):
-            row_next = row_iter.contents.next
+            row_next = row_iter.contents.__next__
             lib_nsh.netsnmp_table_dataset_remove_and_delete_row(self.table, row_iter)
             row_iter = row_next
 
@@ -535,7 +535,7 @@ class AgentX(object):
         block = ctypes.c_int(0)
         num_fds = ctypes.c_int(0)
         readers = fd_set()
-        timeout = timeval(sys.maxint, 0)
+        timeout = timeval(sys.maxsize, 0)
 
         lib_nsh.snmp_select_info(ctypes.byref(num_fds), ctypes.byref(readers), ctypes.byref(timeout), ctypes.byref(block))
         count = lib_c.select(num_fds, ctypes.byref(readers), None, None, ctypes.byref(timeout) if not block else None)

--- a/lib/snmpy/agentx.py
+++ b/lib/snmpy/agentx.py
@@ -364,7 +364,7 @@ class ASNType(object):
         return self._data.value
 
     def set_value(self, data):
-        self._data.value = data
+        self._data.value = data.encode('ascii') if isinstance(data, str) else data
         if hasattr(self, '_watcher'):
             self._watcher.contents.data_size = self.data_size()
 
@@ -382,7 +382,7 @@ class ASNType(object):
 
 class OctetString(ASNType):
     def __init__(self, data=''):
-        self._data     = ctypes.create_unicode_buffer(data[:MAX_STR_LEN], MAX_STR_LEN)
+        self._data     = ctypes.create_string_buffer(data[:MAX_STR_LEN].encode('ascii'), MAX_STR_LEN)
         self._type     = ASN_OCTET_STR
         self._flags    = WATCHER_MAX_SIZE
         self._max_size = MAX_STR_LEN
@@ -459,11 +459,11 @@ class AgentX(object):
         self.data = {}
 
         lib_nsa.netsnmp_enable_subagent()
-        lib_nsa.init_agent(self.name.encode('utf8'))
+        lib_nsa.init_agent(self.name.encode('ascii'))
 
         lib_nsa.netsnmp_init_mib()
         if mib is not None:
-            lib_nsa.read_mib(mib.encode('utf8'))
+            lib_nsa.read_mib(mib.encode('ascii'))
 
     def ObjectFactory(func):
         def wrapped(self, val=None, oid=None):
@@ -494,14 +494,14 @@ class AgentX(object):
         return tbl
 
     def start_subagent(self):
-        lib_nsa.init_snmp(self.name.encode('utf8'))
+        lib_nsa.init_snmp(self.name.encode('ascii'))
 
     def create_handler(self, oid):
         root_len = ctypes.c_size_t(MAX_OID_LEN)
         root_oid = (ctypes.c_ulong * MAX_OID_LEN)()
-        lib_nsh.read_objid(oid.encode('utf8'), root_oid, ctypes.byref(root_len))
+        lib_nsh.read_objid(oid.encode('ascii'), root_oid, ctypes.byref(root_len))
 
-        return lib_nsh.netsnmp_create_handler_registration(oid.encode('utf8'), None, root_oid, root_len, 0)
+        return lib_nsh.netsnmp_create_handler_registration(oid.encode('ascii'), None, root_oid, root_len, 0)
 
     def register_value(self, obj, oid):
         if oid not in self.data:

--- a/lib/snmpy/agentx.py
+++ b/lib/snmpy/agentx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import ctypes.util
 import sys
@@ -47,7 +47,7 @@ FD_SETSIZE      = 1024
 class fd_set(ctypes.Structure):
     pass
 fd_set._fields_ = (
-    ('fds_bits', ctypes.c_long * (FD_SETSIZE / (8 * ctypes.sizeof(ctypes.c_long)))),
+    ('fds_bits', ctypes.c_long * (FD_SETSIZE // (8 * ctypes.sizeof(ctypes.c_long)))),
 )
 
 lib_c.select.restype  = ctypes.c_int
@@ -382,7 +382,7 @@ class ASNType(object):
 
 class OctetString(ASNType):
     def __init__(self, data=''):
-        self._data     = ctypes.create_string_buffer(data[:MAX_STR_LEN], MAX_STR_LEN)
+        self._data     = ctypes.create_unicode_buffer(data[:MAX_STR_LEN], MAX_STR_LEN)
         self._type     = ASN_OCTET_STR
         self._flags    = WATCHER_MAX_SIZE
         self._max_size = MAX_STR_LEN
@@ -459,11 +459,11 @@ class AgentX(object):
         self.data = {}
 
         lib_nsa.netsnmp_enable_subagent()
-        lib_nsa.init_agent(self.name)
+        lib_nsa.init_agent(self.name.encode('utf8'))
 
         lib_nsa.netsnmp_init_mib()
         if mib is not None:
-            lib_nsa.read_mib(mib)
+            lib_nsa.read_mib(mib.encode('utf8'))
 
     def ObjectFactory(func):
         def wrapped(self, val=None, oid=None):
@@ -494,14 +494,14 @@ class AgentX(object):
         return tbl
 
     def start_subagent(self):
-        lib_nsa.init_snmp(self.name)
+        lib_nsa.init_snmp(self.name.encode('utf8'))
 
     def create_handler(self, oid):
         root_len = ctypes.c_size_t(MAX_OID_LEN)
         root_oid = (ctypes.c_ulong * MAX_OID_LEN)()
-        lib_nsh.read_objid(oid, root_oid, ctypes.byref(root_len))
+        lib_nsh.read_objid(oid.encode('utf8'), root_oid, ctypes.byref(root_len))
 
-        return lib_nsh.netsnmp_create_handler_registration(oid, None, root_oid, root_len, 0)
+        return lib_nsh.netsnmp_create_handler_registration(oid.encode('utf8'), None, root_oid, root_len, 0)
 
     def register_value(self, obj, oid):
         if oid not in self.data:

--- a/lib/snmpy/httpd.py
+++ b/lib/snmpy/httpd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2.7
 
-import BaseHTTPServer
+import http.server
 
 import collections
 import logging
@@ -11,8 +11,8 @@ import sys
 import signal
 import time
 import traceback
-import urllib
-import urlparse
+import urllib.request, urllib.parse, urllib.error
+import urllib.parse
 
 from snmpy import log_error, __version__
 
@@ -42,7 +42,7 @@ class Response():
             'body': '',
         })
 
-        for key, val in kwargs.items():
+        for key, val in list(kwargs.items()):
             if key == 'head':
                 self.head.update(kwargs['head'])
             else:
@@ -51,20 +51,20 @@ class Response():
     def __setattr__(self, key, val):
         if key.startswith('_') or key == 'head' or key not in self.__dict__:
             raise AttributeError('setting attribute %s is not supported' % key)
-        if key == 'code' and type(val) != int:
+        if key == 'code' and not isinstance(val, int):
             raise AttributeError('setting attribute %s requires an integer' % key)
 
         self.__dict__[key] = val
 
 
-class Server(BaseHTTPServer.HTTPServer):
+class Server(http.server.HTTPServer):
     allow_reuse_address = True
 
     def __init__(self, port, addr='', **kwargs):
-        BaseHTTPServer.HTTPServer.__init__(self, (addr, port), Handler)
+        http.server.HTTPServer.__init__(self, (addr, port), Handler)
 
         Handler.log_message     = lambda *args: True
-        Handler.extra_settings  = collections.namedtuple('extra_settings', kwargs.keys())(*kwargs.values())
+        Handler.extra_settings  = collections.namedtuple('extra_settings', list(kwargs.keys()))(*list(kwargs.values()))
         Handler.server_version += ' %s/%s' % (__name__, __version__)
 
         try:
@@ -75,7 +75,7 @@ class Server(BaseHTTPServer.HTTPServer):
     def server_bind(self):
         self.socket.setsockopt(socket.SOL_TCP, socket.TCP_DEFER_ACCEPT, True)
         self.socket.setsockopt(socket.SOL_TCP, socket.TCP_QUICKACK,     True)
-        BaseHTTPServer.HTTPServer.server_bind(self)
+        http.server.HTTPServer.server_bind(self)
 
     def process_request(self, *args):
         def handle_timeout(*args):
@@ -85,14 +85,14 @@ class Server(BaseHTTPServer.HTTPServer):
             signal.signal(signal.SIGALRM, handle_timeout)
             signal.alarm(10)
 
-            BaseHTTPServer.HTTPServer.process_request(self, *args)
+            http.server.HTTPServer.process_request(self, *args)
         except Exception as e:
             log_error(e)
         finally:
             signal.alarm(0)
 
 
-class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
+class Handler(http.server.BaseHTTPRequestHandler):
     protocol_version = 'HTTP/1.1'
 
     request_handlers = {
@@ -107,14 +107,14 @@ class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
     def route_request(self, method):
         self.start_time  = time.time() * 1000
 
-        self.url   = urlparse.urlparse(self.path)
-        self.path  = urllib.unquote(self.url.path)
-        self.query = urlparse.parse_qs(self.url.query)
+        self.url   = urllib.parse.urlparse(self.path)
+        self.path  = urllib.parse.unquote(self.url.path)
+        self.query = urllib.parse.parse_qs(self.url.query)
 
         response = Response(head=self.default_headers)
 
         try:
-            for patt, func in self.request_handlers[method].items():
+            for patt, func in list(self.request_handlers[method].items()):
                 find = patt.match(self.path)
                 if find:
                     response = Response(head=self.default_headers)
@@ -131,7 +131,7 @@ class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
             response.body = e.body
 
         self.send_response(response.code, response.line)
-        for key, val in response.head.items():
+        for key, val in list(response.head.items()):
             if key.lower() != 'content-length':
                 self.send_header(key, val)
         self.send_header('Content-length', len(response.body))
@@ -145,7 +145,7 @@ class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
 
 def GET(path=None):
     def wrapper(func):
-        patt = r'/%s(?:/|$)' % (path.strip('/') if path is not None else func.func_name.replace('_', '-'))
+        patt = r'/%s(?:/|$)' % (path.strip('/') if path is not None else func.__name__.replace('_', '-'))
         Handler.request_handlers['GET'][re.compile(patt)] = func
     return wrapper
 

--- a/lib/snmpy/httpd.py
+++ b/lib/snmpy/httpd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 import http.server
 
@@ -138,7 +138,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self.send_header('X-Handler-Time', '%.02fms' % (time.time() * 1000 - self.start_time))
         self.send_header('X-Handler-Pid', os.getpid())
         self.end_headers()
-        self.wfile.write(response.body)
+        self.wfile.write(response.body.encode('utf8'))
 
     def do_GET(self):
         self.route_request('GET')

--- a/lib/snmpy/httpd.py
+++ b/lib/snmpy/httpd.py
@@ -138,7 +138,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self.send_header('X-Handler-Time', '%.02fms' % (time.time() * 1000 - self.start_time))
         self.send_header('X-Handler-Pid', os.getpid())
         self.end_headers()
-        self.wfile.write(response.body.encode('utf8'))
+        self.wfile.write(response.body.encode('ascii'))
 
     def do_GET(self):
         self.route_request('GET')

--- a/lib/snmpy/mibgen.py
+++ b/lib/snmpy/mibgen.py
@@ -21,7 +21,7 @@ def get_syntax(key, type_map=collections.OrderedDict()):
         type_map['Counter64'] = re.compile(r'(?:long|int(?:eger)?64|count(?:er)?64)')
         type_map['Integer32'] = re.compile(r'(?:int(?:eger)?|count)(?:32)?')
 
-    for name, info in type_map.items():
+    for name, info in list(type_map.items()):
         if info.match(key):
             return object_syntax(name, name, int)
 

--- a/lib/snmpy/module/__init__.py
+++ b/lib/snmpy/module/__init__.py
@@ -23,9 +23,7 @@ class Meta(type):
         return super(Meta, cls).__new__(cls, name, bases, attrs)
 
 
-class Module(object):
-    __metaclass__ = Meta
-
+class Module(object, metaclass=Meta):
     def __init__(self, conf):
         self.conf = conf
         self.name = conf['name']
@@ -34,7 +32,7 @@ class Module(object):
         pass
 
     def update(self):
-        raise(NotImplementedError('module is missing update() method'))
+        raise NotImplementedError
 
 
 class ModuleItem(object):
@@ -56,7 +54,7 @@ class ValueModule(Module):
         self.attrs['cdef'] = self.attrs.get('cdef', None)
         self.attrs['join'] = self.attrs.get('join', '')
         for oid in range(len(self.conf['items'])):
-            obj, cfg = self.conf['items'][oid].items().pop()
+            obj, cfg = list(self.conf['items'][oid].items()).pop()
 
             oidstr = snmpy.mibgen.get_oidstr(self.name, obj)
             syntax = snmpy.mibgen.get_syntax(cfg['type'])
@@ -108,7 +106,7 @@ class TableModule(Module):
         self.rows = []
         self.cols = collections.OrderedDict()
         for oid in range(len(self.conf['table'])):
-            obj, cfg = self.conf['table'][oid].items().pop()
+            obj, cfg = list(self.conf['table'][oid].items()).pop()
 
             if not isinstance(cfg, dict):
                 cfg = {'type': cfg}
@@ -130,10 +128,10 @@ class TableModule(Module):
     def append(self, data):
         self.rows.append([])
         if type(data) in (list, tuple):
-            for col in self.cols.values():
+            for col in list(self.cols.values()):
                 self.rows[-1].append(col.syntax.native_type(data[col.oidnum - 1]))
         elif isinstance(data, dict):
-            for key, col in self.cols.items():
+            for key, col in list(self.cols.items()):
                 self.rows[-1].append(col.syntax.native_type(data[key]))
 
     def load(self):

--- a/lib/snmpy/module/disk_utilization.py
+++ b/lib/snmpy/module/disk_utilization.py
@@ -25,7 +25,7 @@ class disk_utilization(snmpy.module.TableModule):
         comm = [self.conf.get('sar_command', '/usr/bin/sar'), '-d', '-f', self.conf.get('sysstat_log', '/var/log/sysstat/sa%02d') % date.day, '-s', date.strftime('%H:%M:00')]
 
         LOG.debug('running sar command: %s', ' '.join(comm))
-        for line in subprocess.check_output(comm, stderr=open(os.devnull, 'w')).split('\n'):
+        for line in subprocess.check_output(comm, stderr=open(os.devnull, 'w')).decode('ascii').split('\n'):
             LOG.debug('line: %s', line)
 
             part = line.split()

--- a/lib/snmpy/module/exec_table.py
+++ b/lib/snmpy/module/exec_table.py
@@ -5,6 +5,6 @@ import subprocess
 
 class exec_table(snmpy.module.TableModule):
     def update(self):
-        text = subprocess.Popen(self.conf['object'].format(**self.conf['snmpy_extra']), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()[0]
+        text = subprocess.Popen(self.conf['object'].format(**self.conf['snmpy_extra']), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="ascii").communicate()[0]
         for item in snmpy.parser.parse_table(self.conf['parser'], text):
             self.append(item)

--- a/lib/snmpy/module/exec_value.py
+++ b/lib/snmpy/module/exec_value.py
@@ -12,6 +12,6 @@ class exec_value(snmpy.module.ValueModule):
         snmpy.module.ValueModule.__init__(self, conf)
 
     def update(self):
-        text = subprocess.Popen(self.conf['object'].format(**self.conf['snmpy_extra']), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()[0]
+        text = subprocess.Popen(self.conf['object'].format(**self.conf['snmpy_extra']), shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="ascii").communicate()[0]
         for item in self:
             self[item] = snmpy.parser.parse_value(text, self[item])

--- a/lib/snmpy/module/filesystem_space.py
+++ b/lib/snmpy/module/filesystem_space.py
@@ -24,7 +24,7 @@ class filesystem_space(snmpy.module.TableModule):
         snmpy.module.TableModule.__init__(self, conf)
 
     def _unescape_path(self, path):
-		return re.sub(r'(\\[0-3][0-7][0-7])', lambda x: chr((ord(x.group(0)[1]) - 48) * 64 + (ord(x.group(0)[2]) - 48) * 8 + (ord(x.group(0)[3]) - 48)), path)
+        return re.sub(r'(\\[0-3][0-7][0-7])', lambda x: chr((ord(x.group(0)[1]) - 48) * 64 + (ord(x.group(0)[2]) - 48) * 8 + (ord(x.group(0)[3]) - 48)), path)
 
     def update(self):
         seen = set()

--- a/lib/snmpy/module/process_info.py
+++ b/lib/snmpy/module/process_info.py
@@ -20,7 +20,7 @@ class process_data(object):
 
         for line in open('/proc/%s/limits' % pid):
             if line.startswith('Max'):
-                data = map(str.strip, filter(None, line.split('  ')))
+                data = list(map(str.strip, [_f for _f in line.split('  ') if _f]))
                 self._l['_'.join(data[0].strip().split()[1:])] = data[1:-1]
 
     @property
@@ -91,7 +91,7 @@ class process_info(snmpy.module.TableModule):
 
             try:
                 p = process_data(pid)
-                self.append([getattr(p, c) for c in self.cols.keys()])
+                self.append([getattr(p, c) for c in list(self.cols.keys())])
             except Exception as e:
                 if isinstance(e, EnvironmentError) and e.errno == errno.ENOENT:
                     LOG.debug('%s: disappeared while gathering info', pid)

--- a/lib/snmpy/module/raid_info.py
+++ b/lib/snmpy/module/raid_info.py
@@ -16,7 +16,7 @@ class raid_info(snmpy.module.TableModule):
             {'member_state': 'string'},
         ]
 
-        if type(conf['type']) in (str, unicode):
+        if type(conf['type']) in (str, str):
             conf['type'] = [conf['type']]
 
         snmpy.module.TableModule.__init__(self, conf)
@@ -67,7 +67,7 @@ class raid_info(snmpy.module.TableModule):
                     }
                     continue
 
-                for attr, rexp in patt['attrs'].items():
+                for attr, rexp in list(patt['attrs'].items()):
                     find = rexp.search(line)
                     if find:
                         raid[name][attr] = find.group(attr.upper())

--- a/lib/snmpy/module/raid_info.py
+++ b/lib/snmpy/module/raid_info.py
@@ -58,7 +58,7 @@ class raid_info(snmpy.module.TableModule):
                 return 'ACTIVE'
 
         try:
-            for line in subprocess.check_output('/sbin/mdadm --detail --scan --verbose --verbose'.split()).split('\n'):
+            for line in subprocess.check_output('/sbin/mdadm --detail --scan --verbose --verbose'.split()).decode('ascii').split('\n'):
                 find = patt['label'].match(line)
                 if find:
                     name = find.group('LABEL')

--- a/lib/snmpy/parser.py
+++ b/lib/snmpy/parser.py
@@ -33,12 +33,12 @@ def parse_table(parser, text):
     if 'type' not in parser or parser['type'] not in ['regex']:
         LOG.warn('invalid or missing parser type: %s', parser.get('path'))
         yield
-    if 'path' not in parser or type(parser['path']) not in (str, unicode, list, tuple):
+    if 'path' not in parser or type(parser['path']) not in (str, str, list, tuple):
         LOG.warn('invalid or missing parser path: %s', parser.get('path'))
         yield
 
     if parser['type'] == 'regex':
-        if type(parser['path']) in (str, unicode):
+        if type(parser['path']) in (str, str):
             patt = parser['path']
         elif type(parser['path']) in (list, tuple):
             patt = '.*?'.join(parser['path'])

--- a/lib/snmpy/server.py
+++ b/lib/snmpy/server.py
@@ -1,4 +1,4 @@
-import httpd
+from . import httpd
 import logging
 import multiprocessing
 import signal
@@ -98,7 +98,7 @@ class SnmpyAgent(object):
                     getattr(self.snmp, mod[item].syntax.object_type)(mod[item].value, mod[item].oidstr)
 
             elif isinstance(mod, snmpy.module.TableModule):
-                self.snmp.Table(snmpy.mibgen.get_oidstr(mod.name, 'table'), *list(getattr(self.snmp, col.syntax.object_type)() for col in mod.cols.values()))
+                self.snmp.Table(snmpy.mibgen.get_oidstr(mod.name, 'table'), *list(getattr(self.snmp, col.syntax.object_type)() for col in list(mod.cols.values())))
 
             self.start_fetch(mod)
 

--- a/lib/snmpy/server.py
+++ b/lib/snmpy/server.py
@@ -75,7 +75,7 @@ class SnmpyAgent(object):
 
 
     def start_agent(self):
-        temp = tempfile.NamedTemporaryFile()
+        temp = tempfile.NamedTemporaryFile(mode="w")
         temp.write(self.text)
         temp.flush()
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 import glob
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         scripts=['snmpy'] + glob.glob('scripts/*'),
         packages=['snmpy', 'snmpy.module'],
         package_dir={'snmpy': 'lib/snmpy'},
-        data_files=confs.items(),
+        data_files=list(confs.items()),
         license='LICENSE.txt',
         install_requires=['yaml', 'setuptools']
     )

--- a/snmpy
+++ b/snmpy
@@ -21,7 +21,10 @@ LOG = logging.getLogger()
 def parse_conf(parser):
     try:
         args = parser.parse_args()
-        conf = yaml.load(open(args.config_file), Loader=yaml.FullLoader)
+        try:
+            conf = yaml.load(open(args.config_file), Loader=yaml.FullLoader)
+        except:
+            conf = yaml.load(open(args.config_file))
 
         if args.create_mib:
             conf['snmpy_global']['create_pid'] = None
@@ -56,7 +59,10 @@ def parse_conf(parser):
                     'snmpy_index': int(indx),
                     'snmpy_extra': dict(args.extra_data),
                 }
-                conf[name].update(yaml.load(open(item), Loader=yaml.FullLoader) or {})
+                try:
+                    conf[name].update(yaml.load(open(item), Loader=yaml.FullLoader) or {})
+                except:
+                    conf[name].update(yaml.load(open(item)) or {})
 
                 if conf['snmpy_global']['persist_dir'] and conf[name].get('retain', False):
                     conf[name]['save'] = '%s/%s.dat' % (conf['snmpy_global']['persist_dir'], name)

--- a/snmpy
+++ b/snmpy
@@ -12,7 +12,7 @@ import snmpy.server
 import socket
 import sys
 import textwrap
-import urlparse
+import urllib.parse
 import yaml
 
 LOG = logging.getLogger()
@@ -46,7 +46,7 @@ def parse_conf(parser):
                     raise ValueError('%s: plugin name already assigned at another index', name)
                 if int(indx) < 1:
                     raise ValueError('%s: invalid plugin index', indx)
-                if int(indx) in list(v['snmpy_index'] for k, v in conf.items() if k != 'snmpy_global'):
+                if int(indx) in list(v['snmpy_index'] for k, v in list(conf.items()) if k != 'snmpy_global'):
                     raise ValueError('%s: index already assigned to another plugin', indx)
 
                 conf[name] = {
@@ -73,8 +73,8 @@ def create_log(logger=None):
     fmt = '%(asctime)s.%(msecs)03d%(module)20s:%(lineno)-3d %(threadName)-12s %(levelname)8s: %(message)s'
 
     if logger:
-        url = urlparse.urlparse(logger)
-        arg = urlparse.parse_qs(url.query)
+        url = urllib.parse.urlparse(logger)
+        arg = urllib.parse.parse_qs(url.query)
 
         if url.scheme in ('file', '') and url.path:
             log = logging.handlers.WatchedFileHandler(url.path)
@@ -157,7 +157,7 @@ def initialize(conf):
         snmpy.log_fatal(e, 'initialization failed')
 
     LOG.info('initialization complete')
-    return plugins.values()
+    return list(plugins.values())
 
 
 if __name__ == '__main__':

--- a/snmpy
+++ b/snmpy
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 import argparse
 import collections
@@ -21,7 +21,7 @@ LOG = logging.getLogger()
 def parse_conf(parser):
     try:
         args = parser.parse_args()
-        conf = yaml.load(open(args.config_file))
+        conf = yaml.load(open(args.config_file), Loader=yaml.FullLoader)
 
         if args.create_mib:
             conf['snmpy_global']['create_pid'] = None
@@ -56,7 +56,7 @@ def parse_conf(parser):
                     'snmpy_index': int(indx),
                     'snmpy_extra': dict(args.extra_data),
                 }
-                conf[name].update(yaml.load(open(item)) or {})
+                conf[name].update(yaml.load(open(item), Loader=yaml.FullLoader) or {})
 
                 if conf['snmpy_global']['persist_dir'] and conf[name].get('retain', False):
                     conf[name]['save'] = '%s/%s.dat' % (conf['snmpy_global']['persist_dir'], name)
@@ -161,7 +161,10 @@ def initialize(conf):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Modular SNMP AgentX system', version=snmpy.__version__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description='Modular SNMP AgentX system',
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('-v', '--version', action='version', version=snmpy.__version__)
     parser.add_argument('-f', '--config-file', default='/etc/snmpy/snmpy.yml',
                         help='system configuration file')
     parser.add_argument('-i', '--include-dir', default='/etc/snmpy/conf.d',


### PR DESCRIPTION
Automated and manual change this code base from python2 -> python3.

See individual commits for details, but short:

* python's 2to3 conversion utility ran
* Changes to deal with python3's new default ways of handling strings (lots of encoding()'s needed now), some naming changes, and a few new python3-ism, etc)
* Updated debian directory for building python3

So far, tested on Ubuntu focal, bionic